### PR TITLE
🔀 :: (#9) User API에 토큰으로 유저 이메일 조회 추가

### DIFF
--- a/src/main/kotlin/com/jpi/api/UserApi.kt
+++ b/src/main/kotlin/com/jpi/api/UserApi.kt
@@ -1,5 +1,6 @@
 package com.jpi.api
 
+import com.jpi.domain.usecase.auth.GetEmailByTokenUseCase
 import com.jpi.domain.usecase.user.GetAllStudentUseCase
 import com.jpi.domain.usecase.user.GetStudentUseCase
 import io.ktor.http.*
@@ -11,9 +12,20 @@ import org.koin.ktor.ext.inject
 fun Route.userRoute() {
     val getStudentUseCase: GetStudentUseCase by inject()
     val getAllStudentUseCase: GetAllStudentUseCase by inject()
+    val getEmailByTokenUseCase: GetEmailByTokenUseCase by inject()
+
+    val tokenPrefix = "Bearer "
 
     get("user") {
-        val email = ""
+        val accessToken = call.request.headers[HttpHeaders.Authorization] ?: return@get call.respondText(
+            status = HttpStatusCode.BadRequest,
+            text = "잘못된 요청입니다."
+        )
+        if (!accessToken.startsWith(tokenPrefix)) call.respondText(
+            status = HttpStatusCode.Unauthorized,
+            text = "유효하지 않은 토큰입니다."
+        )
+        val email = getEmailByTokenUseCase(accessToken = accessToken.removePrefix("Bearer "))
         val student = getStudentUseCase(email = email)
             ?: call.respondText(status = HttpStatusCode.NotFound, text = "유저를 찾을 수 없습니다.")
 

--- a/src/main/kotlin/com/jpi/api/UserApi.kt
+++ b/src/main/kotlin/com/jpi/api/UserApi.kt
@@ -25,7 +25,7 @@ fun Route.userRoute() {
             status = HttpStatusCode.Unauthorized,
             text = "유효하지 않은 토큰입니다."
         )
-        val email = getEmailByTokenUseCase(accessToken = accessToken.removePrefix("Bearer "))
+        val email = getEmailByTokenUseCase(accessToken = accessToken.removePrefix(tokenPrefix))
         val student = getStudentUseCase(email = email)
             ?: call.respondText(status = HttpStatusCode.NotFound, text = "유저를 찾을 수 없습니다.")
 


### PR DESCRIPTION
## 작업 내용
- 유저 조회시 토큰으로 유저 이메일을 조회하는 로직을 추가하였습니다.
- 요청 헤더 토큰 prefix 처리 로직을 추가하였습니다.