### PR TITLE
🔀 :: (#13) 로그아웃 API 작성

### DIFF
--- a/src/main/kotlin/com/jpi/api/UserApi.kt
+++ b/src/main/kotlin/com/jpi/api/UserApi.kt
@@ -2,9 +2,7 @@ package com.jpi.api
 
 import com.jpi.data.model.request.UserRequest
 import com.jpi.domain.usecase.auth.GetEmailByTokenUseCase
-import com.jpi.domain.usecase.user.GetAllStudentUseCase
-import com.jpi.domain.usecase.user.GetStudentUseCase
-import com.jpi.domain.usecase.user.RestrictRentalUseCase
+import com.jpi.domain.usecase.user.*
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
@@ -18,6 +16,8 @@ fun Route.userRoute() {
     val getAllStudentUseCase: GetAllStudentUseCase by inject()
     val getEmailByTokenUseCase: GetEmailByTokenUseCase by inject()
     val restrictRentalUseCase: RestrictRentalUseCase by inject()
+    val getUUIDUseCase: GetUUIDUseCase by inject()
+    val logoutUseCase: LogoutUseCase by inject()
 
     val tokenPrefix = "Bearer "
 
@@ -48,5 +48,21 @@ fun Route.userRoute() {
         )
         restrictRentalUseCase(id = UUID.fromString(userRequest.id))
         call.respondText(status = HttpStatusCode.OK, text = "학생을 제재하였습니다.")
+    }
+    delete("user/logout") {
+        val accessToken = call.request.headers[HttpHeaders.Authorization] ?: return@delete call.respondText(
+            status = HttpStatusCode.BadRequest,
+            text = "잘못된 요청입니다."
+        )
+        if (!accessToken.startsWith(tokenPrefix)) call.respondText(
+            status = HttpStatusCode.Unauthorized,
+            text = "유효하지 않은 토큰입니다."
+        )
+        val uuid = getUUIDUseCase(accessToken) ?: return@delete call.respondText(
+            status = HttpStatusCode.NotFound,
+            text = "유저를 찾을 수 없습니다."
+        )
+        logoutUseCase(uuid)
+        call.respondText(status = HttpStatusCode.OK, text = "로그아웃 하였습니다.")
     }
 }

--- a/src/main/kotlin/com/jpi/api/UserApi.kt
+++ b/src/main/kotlin/com/jpi/api/UserApi.kt
@@ -61,7 +61,7 @@ fun Route.userRoute() {
             status = HttpStatusCode.Unauthorized,
             text = "유효하지 않은 토큰입니다."
         )
-        val uuid = getUUIDUseCase(accessToken) ?: return@delete call.respondText(
+        val uuid = getUUIDUseCase(accessToken.removePrefix(tokenPrefix)) ?: return@delete call.respondText(
             status = HttpStatusCode.NotFound,
             text = "유저를 찾을 수 없습니다."
         )

--- a/src/main/kotlin/com/jpi/api/UserApi.kt
+++ b/src/main/kotlin/com/jpi/api/UserApi.kt
@@ -2,6 +2,7 @@ package com.jpi.api
 
 import com.jpi.data.model.request.UserRequest
 import com.jpi.domain.usecase.auth.GetEmailByTokenUseCase
+import com.jpi.domain.usecase.auth.IsTokenValidUseCase
 import com.jpi.domain.usecase.user.*
 import io.ktor.http.*
 import io.ktor.server.application.*
@@ -18,6 +19,7 @@ fun Route.userRoute() {
     val restrictRentalUseCase: RestrictRentalUseCase by inject()
     val getUUIDUseCase: GetUUIDUseCase by inject()
     val logoutUseCase: LogoutUseCase by inject()
+    val isTokenValidUseCase: IsTokenValidUseCase by inject()
 
     val tokenPrefix = "Bearer "
 
@@ -26,10 +28,11 @@ fun Route.userRoute() {
             status = HttpStatusCode.BadRequest,
             text = "잘못된 요청입니다."
         )
-        if (!accessToken.startsWith(tokenPrefix)) call.respondText(
+        if (!accessToken.startsWith(tokenPrefix) || !isTokenValidUseCase(accessToken)) call.respondText(
             status = HttpStatusCode.Unauthorized,
             text = "유효하지 않은 토큰입니다."
         )
+
         val email = getEmailByTokenUseCase(accessToken = accessToken.removePrefix(tokenPrefix))
         val student = getStudentUseCase(email = email)
             ?: call.respondText(status = HttpStatusCode.NotFound, text = "유저를 찾을 수 없습니다.")

--- a/src/main/kotlin/com/jpi/data/repository/AuthRepositoryImpl.kt
+++ b/src/main/kotlin/com/jpi/data/repository/AuthRepositoryImpl.kt
@@ -91,10 +91,10 @@ class AuthRepositoryImpl(private val client: HttpClient) : AuthRepository {
             .single()
 
         val refreshToken = RefreshToken.select { RefreshToken.id eq uuid }
-            .map { it[User.id] }
+            .map { it[RefreshToken.refreshToken] }
             .single()
 
-        refreshToken.toString() != ""
+        refreshToken != ""
     }
 
     private suspend fun createUserOrRefreshToken(gAuthUserInfo: GAuthUserResponse, refreshToken: String) = dbQuery {

--- a/src/main/kotlin/com/jpi/data/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/com/jpi/data/repository/UserRepositoryImpl.kt
@@ -1,16 +1,22 @@
 package com.jpi.data.repository
 
 import com.jpi.data.model.response.asUserResponse
+import com.jpi.domain.entity.RefreshToken
 import com.jpi.domain.entity.User
+import com.jpi.domain.model.response.GAuthUserResponse
 import com.jpi.domain.model.response.UserResponse
 import com.jpi.domain.repository.UserRepository
 import com.jpi.server.DatabaseFactory.dbQuery
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import java.util.*
 
-class UserRepositoryImpl: UserRepository {
+class UserRepositoryImpl(private val client: HttpClient): UserRepository {
     override suspend fun getStudent(email: String): UserResponse? = dbQuery {
         User.select { User.email eq email }
             .map { it.asUserResponse() }
@@ -24,6 +30,23 @@ class UserRepositoryImpl: UserRepository {
     override suspend fun restrictRental(id: UUID): Unit = dbQuery {
         User.update({User.id eq id}) {
             it[isRentalRestricted] = true
+        }
+    }
+
+    override suspend fun getUUID(accessToken: String): UUID? = dbQuery {
+        val gAuthUserInfo = client.get("https://open.gauth.co.kr/user") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }.body<GAuthUserResponse>()
+
+        User.select { User.email eq gAuthUserInfo.email }
+            .map { it[User.id] }
+            .singleOrNull()
+    }
+
+    override suspend fun logout(id: UUID): Unit = dbQuery {
+        RefreshToken.update({RefreshToken.id eq id}) {
+            it[refreshToken] = ""
         }
     }
 }

--- a/src/main/kotlin/com/jpi/di/RepositoryModule.kt
+++ b/src/main/kotlin/com/jpi/di/RepositoryModule.kt
@@ -7,6 +7,6 @@ import com.jpi.domain.repository.UserRepository
 import org.koin.dsl.module
 
 val repositoryModule = module {
-    single<UserRepository> { UserRepositoryImpl() }
+    single<UserRepository> { UserRepositoryImpl(get()) }
     single<AuthRepository> { AuthRepositoryImpl(get()) }
 }

--- a/src/main/kotlin/com/jpi/di/UseCaseModule.kt
+++ b/src/main/kotlin/com/jpi/di/UseCaseModule.kt
@@ -3,9 +3,7 @@ package com.jpi.di
 import com.jpi.domain.usecase.auth.GetEmailByTokenUseCase
 import com.jpi.domain.usecase.auth.ReissueTokenUseCase
 import com.jpi.domain.usecase.auth.SignInUseCase
-import com.jpi.domain.usecase.user.GetAllStudentUseCase
-import com.jpi.domain.usecase.user.GetStudentUseCase
-import com.jpi.domain.usecase.user.RestrictRentalUseCase
+import com.jpi.domain.usecase.user.*
 import org.koin.dsl.module
 
 val useCaseModule = module {
@@ -13,6 +11,8 @@ val useCaseModule = module {
     single { GetStudentUseCase(get()) }
     single { GetAllStudentUseCase(get()) }
     single { RestrictRentalUseCase(get()) }
+    single { GetUUIDUseCase(get()) }
+    single { LogoutUseCase(get()) }
 
     // Auth
     single { ReissueTokenUseCase(get()) }

--- a/src/main/kotlin/com/jpi/di/UseCaseModule.kt
+++ b/src/main/kotlin/com/jpi/di/UseCaseModule.kt
@@ -1,6 +1,7 @@
 package com.jpi.di
 
 import com.jpi.domain.usecase.auth.GetEmailByTokenUseCase
+import com.jpi.domain.usecase.auth.IsTokenValidUseCase
 import com.jpi.domain.usecase.auth.ReissueTokenUseCase
 import com.jpi.domain.usecase.auth.SignInUseCase
 import com.jpi.domain.usecase.user.*
@@ -18,4 +19,5 @@ val useCaseModule = module {
     single { ReissueTokenUseCase(get()) }
     single { SignInUseCase(get()) }
     single { GetEmailByTokenUseCase(get()) }
+    single { IsTokenValidUseCase(get()) }
 }

--- a/src/main/kotlin/com/jpi/domain/entity/RefreshToken.kt
+++ b/src/main/kotlin/com/jpi/domain/entity/RefreshToken.kt
@@ -1,0 +1,10 @@
+package com.jpi.domain.entity
+
+import org.jetbrains.exposed.sql.Table
+
+object RefreshToken: Table() {
+    val id = uuid("id").references(User.id)
+    val refreshToken = text("refresh_token")
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/src/main/kotlin/com/jpi/domain/repository/AuthRepository.kt
+++ b/src/main/kotlin/com/jpi/domain/repository/AuthRepository.kt
@@ -9,4 +9,6 @@ interface AuthRepository {
     suspend fun reissueToken(refreshToken: String): TokenResponse
 
     suspend fun getEmailByToken(accessToken: String): String
+
+    suspend fun isTokenValid(accessToken: String): Boolean
 }

--- a/src/main/kotlin/com/jpi/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/com/jpi/domain/repository/UserRepository.kt
@@ -9,4 +9,8 @@ interface UserRepository {
     suspend fun getAllStudents(): List<UserResponse>
 
     suspend fun restrictRental(id: UUID)
+
+    suspend fun getUUID(accessToken: String): UUID?
+
+    suspend fun logout(id: UUID)
 }

--- a/src/main/kotlin/com/jpi/domain/usecase/auth/IsTokenValidUseCase.kt
+++ b/src/main/kotlin/com/jpi/domain/usecase/auth/IsTokenValidUseCase.kt
@@ -1,0 +1,7 @@
+package com.jpi.domain.usecase.auth
+
+import com.jpi.domain.repository.AuthRepository
+
+class IsTokenValidUseCase(private val repository: AuthRepository) {
+    suspend operator fun invoke(accessToken: String) = repository.isTokenValid(accessToken)
+}

--- a/src/main/kotlin/com/jpi/domain/usecase/user/GetUUIDUseCase.kt
+++ b/src/main/kotlin/com/jpi/domain/usecase/user/GetUUIDUseCase.kt
@@ -1,0 +1,7 @@
+package com.jpi.domain.usecase.user
+
+import com.jpi.domain.repository.UserRepository
+
+class GetUUIDUseCase(private val repository: UserRepository) {
+    suspend operator fun invoke(accessToken: String) = repository.getUUID(accessToken)
+}

--- a/src/main/kotlin/com/jpi/domain/usecase/user/LogoutUseCase.kt
+++ b/src/main/kotlin/com/jpi/domain/usecase/user/LogoutUseCase.kt
@@ -1,0 +1,8 @@
+package com.jpi.domain.usecase.user
+
+import com.jpi.domain.repository.UserRepository
+import java.util.UUID
+
+class LogoutUseCase(private val repository: UserRepository) {
+    suspend operator fun invoke(id: UUID) = repository.logout(id)
+}

--- a/src/main/kotlin/com/jpi/server/DatabaseFactory.kt
+++ b/src/main/kotlin/com/jpi/server/DatabaseFactory.kt
@@ -1,5 +1,6 @@
 package com.jpi.server
 
+import com.jpi.domain.entity.RefreshToken
 import com.jpi.domain.entity.User
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.sql.Database
@@ -17,7 +18,7 @@ object DatabaseFactory {
         val database = Database.connect(jdbcURL, driverClassName, user, password)
 
         transaction(database) {
-            SchemaUtils.create(User)
+            SchemaUtils.create(User, RefreshToken)
         }
     }
 


### PR DESCRIPTION
## 작업 내용
- 리프레시 토큰을 저장할 테이블을 생성하고, 로그아웃 API를 구현하였습니다.
- 요청 헤더에서 얻은 액세스 토큰으로 로그아웃 한 유저인지 판단하는 `isTokenValidUseCase()` 를 구현하였습니다.
- 이미 가입된 회원이 중복으로 로그인 요청을 하는 경우 리프레시 토큰 테이블만 업데이트 하도록 변경했습니다.