### PR TITLE
🔀 :: (#22) 동일한 endpoint를 하나의 route로 관리

### DIFF
--- a/src/main/kotlin/com/jpi/api/AuthApi.kt
+++ b/src/main/kotlin/com/jpi/api/AuthApi.kt
@@ -14,25 +14,27 @@ fun Route.authRoute() {
     val signInUseCase: SignInUseCase by inject()
     val reissueTokenUseCase: ReissueTokenUseCase by inject()
 
-    post("auth/signin") {
-        val signInRequest = call.receiveNullable<SignInRequest>() ?: return@post call.respondText(
-            status = HttpStatusCode.BadRequest,
-            text = "잘못된 요청입니다."
-        )
+    route("auth") {
+        post("/signin") {
+            val signInRequest = call.receiveNullable<SignInRequest>() ?: return@post call.respondText(
+                status = HttpStatusCode.BadRequest,
+                text = "잘못된 요청입니다."
+            )
 
-        val token = signInUseCase(signInRequest = signInRequest)
+            val token = signInUseCase(signInRequest = signInRequest)
 
-        call.respond(status = HttpStatusCode.OK, message = token)
-    }
+            call.respond(status = HttpStatusCode.OK, message = token)
+        }
 
-    patch("auth/reissue") {
-        val refreshToken = call.request.headers["Refresh-Token"] ?: return@patch call.respondText(
-            status = HttpStatusCode.BadRequest,
-            text = "잘못된 요청입니다."
-        )
+        patch("/reissue") {
+            val refreshToken = call.request.headers["Refresh-Token"] ?: return@patch call.respondText(
+                status = HttpStatusCode.BadRequest,
+                text = "잘못된 요청입니다."
+            )
 
-        val token = reissueTokenUseCase(refreshToken = refreshToken)
+            val token = reissueTokenUseCase(refreshToken = refreshToken)
 
-        call.respond(status = HttpStatusCode.OK, message = token)
+            call.respond(status = HttpStatusCode.OK, message = token)
+        }
     }
 }

--- a/src/main/kotlin/com/jpi/api/UserApi.kt
+++ b/src/main/kotlin/com/jpi/api/UserApi.kt
@@ -23,44 +23,46 @@ fun Route.userRoute() {
     val isTokenValidUseCase: IsTokenValidUseCase by inject()
     val isAdminUseCase: IsAdminUseCase by inject()
 
-    get("user") {
-        val accessToken = getAccessToken { isTokenValidUseCase(it) } ?: return@get
-        val email = getEmailByTokenUseCase(accessToken = accessToken)
-        val student = getStudentUseCase(email = email)
-            ?: call.respondText(status = HttpStatusCode.NotFound, text = "유저를 찾을 수 없습니다.")
+    route("user") {
+        get {
+            val accessToken = getAccessToken { isTokenValidUseCase(it) } ?: return@get
+            val email = getEmailByTokenUseCase(accessToken = accessToken)
+            val student = getStudentUseCase(email = email)
+                ?: call.respondText(status = HttpStatusCode.NotFound, text = "유저를 찾을 수 없습니다.")
 
-        call.respond(HttpStatusCode.OK, student)
-    }
-    get("user/all") {
-        val accessToken = getAccessToken { isTokenValidUseCase(it) } ?: return@get
-        if (!isAdminUseCase(accessToken)) call.respondText(
-            status = HttpStatusCode.Forbidden,
-            text = "권한이 없습니다."
-        )
-        val allStudents = getAllStudentUseCase()
+            call.respond(HttpStatusCode.OK, student)
+        }
+        get("/all") {
+            val accessToken = getAccessToken { isTokenValidUseCase(it) } ?: return@get
+            if (!isAdminUseCase(accessToken)) call.respondText(
+                status = HttpStatusCode.Forbidden,
+                text = "권한이 없습니다."
+            )
+            val allStudents = getAllStudentUseCase()
 
-        call.respond(status = HttpStatusCode.OK, message = allStudents)
-    }
-    patch("user/restrict") {
-        val accessToken = getAccessToken { isTokenValidUseCase(it) } ?: return@patch
-        val userRequest = call.receiveNullable<UserRequest>() ?: return@patch call.respondText(
-            status = HttpStatusCode.BadRequest,
-            text = "잘못된 요청입니다."
-        )
-        if (!isAdminUseCase(accessToken)) call.respondText(
-            status = HttpStatusCode.Forbidden,
-            text = "권한이 없습니다."
-        )
-        restrictRentalUseCase(id = UUID.fromString(userRequest.id))
-        call.respondText(status = HttpStatusCode.OK, text = "학생을 제재하였습니다.")
-    }
-    delete("user/logout") {
-        val accessToken = getAccessToken { isTokenValidUseCase(it) } ?: return@delete
-        val uuid = getUUIDUseCase(accessToken) ?: return@delete call.respondText(
-            status = HttpStatusCode.NotFound,
-            text = "유저를 찾을 수 없습니다."
-        )
-        logoutUseCase(uuid)
-        call.respondText(status = HttpStatusCode.OK, text = "로그아웃 하였습니다.")
+            call.respond(status = HttpStatusCode.OK, message = allStudents)
+        }
+        patch("/restrict") {
+            val accessToken = getAccessToken { isTokenValidUseCase(it) } ?: return@patch
+            val userRequest = call.receiveNullable<UserRequest>() ?: return@patch call.respondText(
+                status = HttpStatusCode.BadRequest,
+                text = "잘못된 요청입니다."
+            )
+            if (!isAdminUseCase(accessToken)) call.respondText(
+                status = HttpStatusCode.Forbidden,
+                text = "권한이 없습니다."
+            )
+            restrictRentalUseCase(id = UUID.fromString(userRequest.id))
+            call.respondText(status = HttpStatusCode.OK, text = "학생을 제재하였습니다.")
+        }
+        delete("/logout") {
+            val accessToken = getAccessToken { isTokenValidUseCase(it) } ?: return@delete
+            val uuid = getUUIDUseCase(accessToken) ?: return@delete call.respondText(
+                status = HttpStatusCode.NotFound,
+                text = "유저를 찾을 수 없습니다."
+            )
+            logoutUseCase(uuid)
+            call.respondText(status = HttpStatusCode.OK, text = "로그아웃 하였습니다.")
+        }
     }
 }


### PR DESCRIPTION
## 작업 내용
- AuthApi와 UserApi에서 동일한 endpoint를 하나의 route로 관리하도록 변경하였습니다.